### PR TITLE
🎃 Updates for newer Python / Django versions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,13 @@
+[bumpversion]
+current_version = 0.4.6
+commit = True
+tag = True
+tag_name = {new_version}
+serialize = 
+	{major}.{minor}.{patch}
+	{major}.{minor}
+parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:latest_tweets/__init__.py]

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = true
+parallel = true
+include =
+    latest_tweets/*
+omit =
+    latest_tweets/migrations/*

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Limit Python files to 99 characters
+[*.py]
+max_line_length = 99
+
+# Use 2 spaces for the HTML files
+[*.html]
+indent_size = 2
+
+# The JSON files contain newlines inconsistently
+[*.json]
+indent_size = 4
+insert_final_newline = ignore
+
+# Third party files which may have a wide variety of standards
+[**/static/vendor/**]
+indent_style = ignore
+indent_size = ignore
+
+# Minified JavaScript files shouldn't be changed
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab
+
+# Batch files use tabs for indentation
+[*.bat]
+indent_style = tab

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 99
+exclude = */migrations
+# E203 - whitespace around slice operators, as black enforces equal whitespace.
+# F405 - ignore wildcard variable warnings, as F403 (don't use wildcard imports) should show the
+# problem anyway. But if we really need wildcard imports - we don't want to noqa every variable.
+# W503 - line break before binary operator, considered not PEP 8 compliant by black.
+ignore = E203,F405,W503

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+Sources
+Include links to cards and Sentry errors here.
+
+Description
+What's happening in this PR?
+
+Setup instructions
+Include any environment variables etc. that are needed to test your code.
+
+How to test
+Include a summary of the best way a reviewer can test your code. You don't have to be comprehensive, but give the reviewer an idea of where to start.
+
+For comprehensive guidelines on code review at DEV, see here: https://www.notion.so/developersociety/Code-Review-b6d646b1d6e54011ada8169aee543231.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+on: pull_request
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Python pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/testing.txt') }}
+      - name: Run check
+        run: |
+          pip install tox
+          tox -e check
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Python pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/testing.txt') }}
+      - name: Run lint
+        run: |
+          pip install tox
+          tox -e lint
+
+  test:
+    name: Test -- Python ${{ matrix.python }} - Django ${{ matrix.django }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python:
+          - '3.5'
+          - '3.6'
+          - '3.7'
+          - '3.8'
+        django:
+          - '1.11'
+          - '2.2'
+        exclude:
+          - python: '3.8'
+            django: '1.11'
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Python pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-python${{ matrix.python }}-django${{ matrix.django }}-pip-${{ hashFiles('requirements/testing.txt') }}
+      - name: Run tests
+        env:
+          PYTHON_VERSION: ${{ matrix.python }}
+        run: |
+          pip install tox
+          tox -e py${PYTHON_VERSION//./}-django${{ matrix.django }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
-*.egg-info
 *.pyc
-build
-dist
 MANIFEST
+dist
+build
+*.egg-info
+
+# Tox
+.tox/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[isort]
+combine_as_imports = true
+sections = FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+known_django = django
+include_trailing_comma = false
+line_length = 99
+multi_line_output = 5
+not_skip = __init__.py
+skip_glob = */migrations/*.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2019, Developer Society Limited
+Copyright (c) 2012-2020, Developer Society Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,6 @@
 include README.rst
+include LICENSE
+graft latest_tweets
+global-exclude *.py[co]
+global-exclude __pycache__
+global-exclude .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,159 @@
+SHELL=/bin/bash
+.DEFAULT_GOAL := help
+
+
+# ---------------------------------
+# Project specific targets
+# ---------------------------------
+#
+# Add any targets specific to the current project in here.
+
+
+
+# -------------------------------
+# Common targets for DEV projects
+# -------------------------------
+#
+# Edit these targets so they work as expected on the current project.
+#
+# Remember there may be other tools which use these targets, so if a target is not suitable for
+# the current project, then keep the target and simply make it do nothing.
+
+help: ## This help dialog.
+help: help-display
+
+clean: ## Remove unneeded files generated from the various build tasks.
+clean: build-clean
+
+reset: ## Reset your local environment. Useful after switching branches, etc.
+reset: venv-check venv-wipe install-local
+
+check: ## Check for any obvious errors in the project's setup.
+check: pipdeptree-check
+
+format: ## Run this project's code formatters.
+format: black-format isort-format
+
+lint: ## Lint the project.
+lint: black-lint isort-lint flake8-lint
+
+test: ## Run unit and integration tests.
+test: django-test
+
+test-report: ## Run and report on unit and integration tests.
+test-report: coverage-clean test coverage-report
+
+dist: ## Builds source and wheel package
+dist: clean build-dist
+
+release: ## Package and release this project to PyPI.
+release: dist build-release
+
+
+# ---------------
+# Utility targets
+# ---------------
+#
+# Targets which are used by the common targets. You likely want to customise these per project,
+# to ensure they're pointing at the correct directories, etc.
+
+# Build
+build-clean:
+	rm -rf build
+	rm -rf dist
+	rm -rf .eggs
+	find . -maxdepth 1 -name '*.egg-info' -exec rm -rf {} +
+
+build-release:
+	@echo
+	@echo "This will package and release this project to PyPI."
+	@echo
+	@echo "A checklist before you continue:"
+	@echo
+	@echo " - have you ran 'bumpversion'?"
+	@echo " - have you pushed the commit and tag created by 'bumpversion'?"
+	@echo " - are you sure the project is in a state to be released?"
+	@echo
+	@read -p "Press <enter> to continue. Or <ctrl>-c to quit and address the above points."
+	twine upload dist/*
+
+build-dist:
+	python setup.py sdist
+	python setup.py bdist_wheel
+	ls -l dist
+
+
+# Virtual Environments
+venv-check:
+ifndef VIRTUAL_ENV
+	$(error Must be in a virtualenv)
+endif
+
+venv-wipe: venv-check
+	if ! pip list --format=freeze | grep -v "^pip=\|^setuptools=\|^wheel=" | xargs pip uninstall -y; then \
+	    echo "Nothing to remove"; \
+	fi
+
+
+# Installs
+install-local: pip-install-local
+
+
+# Pip
+pip-install-local: venv-check
+	pip install -r requirements/local.txt
+
+
+# ISort
+isort-lint:
+	isort --recursive --check-only --diff latest_tweets tests
+
+isort-format:
+	isort --recursive latest_tweets tests
+
+
+# Flake8
+flake8-lint:
+	flake8 latest_tweets
+
+
+# Coverage
+coverage-report: coverage-combine coverage-html coverage-xml
+	coverage report --show-missing
+
+coverage-combine:
+	coverage combine
+
+coverage-html:
+	coverage html
+
+coverage-xml:
+	coverage xml
+
+coverage-clean:
+	rm -rf htmlcov
+	rm -f coverage.xml
+	rm -f .coverage
+
+
+# Black
+black-lint:
+	black --line-length 99 --target-version py35 --exclude '/migrations/' --check latest_tweets tests setup.py
+
+black-format:
+	black --line-length 99 --target-version py35 --exclude '/migrations/' latest_tweets tests setup.py
+
+
+#pipdeptree
+pipdeptree-check:
+	@pipdeptree --warn fail > /dev/null
+
+
+# Project testing
+django-test:
+	coverage run $$(which django-admin) test --pythonpath $$(pwd) --settings tests.settings tests
+
+
+# Help
+help-display:
+	@awk '/^[\-[:alnum:]]*: ##/ { split($$0, x, "##"); printf "%20s%s\n", x[1], x[2]; }' $(MAKEFILE_LIST)

--- a/latest_tweets/__init__.py
+++ b/latest_tweets/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "0.4.6"
 
-default_app_config = 'latest_tweets.apps.LatestTweetsConfig'
+default_app_config = "latest_tweets.apps.LatestTweetsConfig"

--- a/latest_tweets/__init__.py
+++ b/latest_tweets/__init__.py
@@ -1,1 +1,3 @@
+__version__ = "0.4.6"
+
 default_app_config = 'latest_tweets.apps.LatestTweetsConfig'

--- a/latest_tweets/admin.py
+++ b/latest_tweets/admin.py
@@ -5,11 +5,14 @@ from .models import Like, Photo, Tweet
 
 class PhotoInline(admin.StackedInline):
     model = Photo
-    readonly_fields = ('photo_id', 'url', 'media_url', 'large_width', 'large_height')
+    readonly_fields = ("photo_id", "url", "media_url", "large_width", "large_height")
     fieldsets = (
-        (None, {
-            'fields': readonly_fields,
-        }),
+        (
+            None,
+            {
+                "fields": readonly_fields,
+            },
+        ),
     )
 
     def has_add_permission(self, request, obj=None):
@@ -21,17 +24,31 @@ class PhotoInline(admin.StackedInline):
 
 @admin.register(Tweet)
 class TweetAdmin(admin.ModelAdmin):
-    list_display = ('user', 'text', 'created')
-    list_filter = ('created', 'user')
-    date_hierarchy = 'created'
+    list_display = ("user", "text", "created")
+    list_filter = ("created", "user")
+    date_hierarchy = "created"
     readonly_fields = (
-        'tweet_id', 'user', 'name', 'text', 'tweet_html', 'hashtags', 'favorite_count',
-        'retweet_count', 'retweeted_username', 'retweeted_name', 'retweeted_tweet_id', 'is_reply',
-        'created')
+        "tweet_id",
+        "user",
+        "name",
+        "text",
+        "tweet_html",
+        "hashtags",
+        "favorite_count",
+        "retweet_count",
+        "retweeted_username",
+        "retweeted_name",
+        "retweeted_tweet_id",
+        "is_reply",
+        "created",
+    )
     fieldsets = (
-        (None, {
-            'fields': readonly_fields,
-        }),
+        (
+            None,
+            {
+                "fields": readonly_fields,
+            },
+        ),
     )
     inlines = [PhotoInline]
 
@@ -40,18 +57,22 @@ class TweetAdmin(admin.ModelAdmin):
 
     def tweet_html(self, obj):
         return obj.html
-    tweet_html.short_description = 'HTML'
+
+    tweet_html.short_description = "HTML"
     tweet_html.allow_tags = True
 
 
 @admin.register(Like)
 class LikeAdmin(admin.ModelAdmin):
-    list_display = ('user', 'tweet')
-    readonly_fields = ('user', 'tweet')
+    list_display = ("user", "tweet")
+    readonly_fields = ("user", "tweet")
     fieldsets = (
-        (None, {
-            'fields': readonly_fields,
-        }),
+        (
+            None,
+            {
+                "fields": readonly_fields,
+            },
+        ),
     )
 
     def has_add_permission(self, request):

--- a/latest_tweets/apps.py
+++ b/latest_tweets/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class LatestTweetsConfig(AppConfig):
-    name = 'latest_tweets'
-    label = 'latest_tweets'
-    verbose_name = 'Latest Tweets'
+    name = "latest_tweets"
+    label = "latest_tweets"
+    verbose_name = "Latest Tweets"

--- a/latest_tweets/management/commands/latest_tweets_auth.py
+++ b/latest_tweets/management/commands/latest_tweets_auth.py
@@ -1,13 +1,15 @@
-from django.core.management.base import BaseCommand
 from django.conf import settings
+from django.core.management.base import BaseCommand
+
 from twitter.oauth_dance import oauth_dance
 
 
 def get_auth_tokens(stdout):
     oauth_token, oauth_secret = oauth_dance(
-        app_name='django-latest-tweets',
+        app_name="django-latest-tweets",
         consumer_key=settings.TWITTER_CONSUMER_KEY,
-        consumer_secret=settings.TWITTER_CONSUMER_SECRET)
+        consumer_secret=settings.TWITTER_CONSUMER_SECRET,
+    )
 
     stdout.write("\nNow add the following lines to your settings.py:\n\n")
     stdout.write("TWITTER_OAUTH_TOKEN = '%s'\n" % (oauth_token,))
@@ -15,7 +17,7 @@ def get_auth_tokens(stdout):
 
 
 class Command(BaseCommand):
-    help = 'Generate OAuth tokens/secret needed for Twitter'
+    help = "Generate OAuth tokens/secret needed for Twitter"
 
     def handle(self, **options):
         get_auth_tokens(self.stdout)

--- a/latest_tweets/management/commands/latest_tweets_update.py
+++ b/latest_tweets/management/commands/latest_tweets_update.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction

--- a/latest_tweets/management/commands/latest_tweets_update.py
+++ b/latest_tweets/management/commands/latest_tweets_update.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
+
 from twitter import OAuth, Twitter
 from twitter.api import TwitterHTTPError
 
@@ -12,12 +13,14 @@ from latest_tweets.utils import update_likes, update_tweets
 
 @transaction.atomic
 def update_user_tweets(user, download):
-    t = Twitter(auth=OAuth(
-        token=settings.TWITTER_OAUTH_TOKEN,
-        token_secret=settings.TWITTER_OAUTH_SECRET,
-        consumer_key=settings.TWITTER_CONSUMER_KEY,
-        consumer_secret=settings.TWITTER_CONSUMER_SECRET
-    ))
+    t = Twitter(
+        auth=OAuth(
+            token=settings.TWITTER_OAUTH_TOKEN,
+            token_secret=settings.TWITTER_OAUTH_SECRET,
+            consumer_key=settings.TWITTER_CONSUMER_KEY,
+            consumer_secret=settings.TWITTER_CONSUMER_SECRET,
+        )
+    )
     tweet_list = t.statuses.user_timeline(screen_name=user, include_rts=True)
     tweet_objs = update_tweets(tweet_list=tweet_list, download=download)
 
@@ -34,52 +37,57 @@ def update_user_tweets(user, download):
 
     # Remove any deleted tweets in our date range
     if oldest_date is not None:
-        Tweet.objects.filter(
-            user=user, created__gt=oldest_date).exclude(id__in=tweet_id_list).delete()
+        Tweet.objects.filter(user=user, created__gt=oldest_date).exclude(
+            id__in=tweet_id_list
+        ).delete()
 
 
 @transaction.atomic
 def update_user_likes(user, download):
-    t = Twitter(auth=OAuth(
-        token=settings.TWITTER_OAUTH_TOKEN,
-        token_secret=settings.TWITTER_OAUTH_SECRET,
-        consumer_key=settings.TWITTER_CONSUMER_KEY,
-        consumer_secret=settings.TWITTER_CONSUMER_SECRET
-    ))
+    t = Twitter(
+        auth=OAuth(
+            token=settings.TWITTER_OAUTH_TOKEN,
+            token_secret=settings.TWITTER_OAUTH_SECRET,
+            consumer_key=settings.TWITTER_CONSUMER_KEY,
+            consumer_secret=settings.TWITTER_CONSUMER_SECRET,
+        )
+    )
     tweet_list = t.favorites.list(screen_name=user)
     update_likes(user=user, tweet_list=tweet_list, download=download)
 
 
 class Command(BaseCommand):
-    help = 'Download and store the latest tweets of followed users'
+    help = "Download and store the latest tweets of followed users"
 
     def add_arguments(self, parser):
+        parser.add_argument("users", metavar="user", nargs="+", help="Twitter username to update")
         parser.add_argument(
-            'users', metavar='user', nargs='+',
-            help='Twitter username to update')
+            "--download-photos",
+            action="store_true",
+            help="Download images from photos and store locally",
+        )
         parser.add_argument(
-            '--download-photos', action='store_true',
-            help='Download images from photos and store locally')
-        parser.add_argument(
-            '--likes', action='store_true',
-            help='Retrieve the list of liked tweets instead of the users tweets')
+            "--likes",
+            action="store_true",
+            help="Retrieve the list of liked tweets instead of the users tweets",
+        )
 
     def handle(self, **options):
-        if options['likes']:
+        if options["likes"]:
             update_user = update_user_likes
         else:
             update_user = update_user_tweets
 
-        for user in options['users']:
+        for user in options["users"]:
             try:
-                update_user(user=user, download=options['download_photos'])
+                update_user(user=user, download=options["download_photos"])
             except TwitterHTTPError as http_error:
                 # Fail quietly on any temporary server error codes. This should avoid raising
                 # exceptions when Twitter has temporary HTTP server problems, but network/DNS
                 # issues should still reraise an exception as that could be an error on our side.
                 if http_error.e.code in (500, 502, 503, 504):
                     self.stderr.write(
-                        'Update failed for {} (HTTP {})'.format(user, http_error.e.code),
+                        "Update failed for {} (HTTP {})".format(user, http_error.e.code),
                     )
                 else:
                     raise

--- a/latest_tweets/migrations/0001_initial.py
+++ b/latest_tweets/migrations/0001_initial.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0002_retweeted.py
+++ b/latest_tweets/migrations/0002_retweeted.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0003_tweet_is_reply.py
+++ b/latest_tweets/migrations/0003_tweet_is_reply.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0004_username_length.py
+++ b/latest_tweets/migrations/0004_username_length.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0005_names.py
+++ b/latest_tweets/migrations/0005_names.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0006_verbose_names.py
+++ b/latest_tweets/migrations/0006_verbose_names.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0007_tweet_html.py
+++ b/latest_tweets/migrations/0007_tweet_html.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0008_photo.py
+++ b/latest_tweets/migrations/0008_photo.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0009_counts.py
+++ b/latest_tweets/migrations/0009_counts.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0010_photo_unique.py
+++ b/latest_tweets/migrations/0010_photo_unique.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/latest_tweets/migrations/0011_photo_image_file.py
+++ b/latest_tweets/migrations/0011_photo_image_file.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 
 

--- a/latest_tweets/migrations/0012_likes.py
+++ b/latest_tweets/migrations/0012_likes.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 
 

--- a/latest_tweets/migrations/0013_hashtags.py
+++ b/latest_tweets/migrations/0013_hashtags.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 
 

--- a/latest_tweets/migrations/0014_display_name_length.py
+++ b/latest_tweets/migrations/0014_display_name_length.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 
 

--- a/latest_tweets/models.py
+++ b/latest_tweets/models.py
@@ -1,10 +1,6 @@
-from __future__ import unicode_literals
-
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class Hashtag(models.Model):
     text = models.CharField(max_length=140, unique=True)
 
@@ -15,10 +11,9 @@ class Hashtag(models.Model):
         return self.text
 
     def get_absolute_url(self):
-        return "https://twitter.com/hashtag/%s" % (self.text,)
+        return "https://twitter.com/hashtag/{}".format(self.text)
 
 
-@python_2_unicode_compatible
 class Tweet(models.Model):
     tweet_id = models.BigIntegerField("Tweet ID", unique=True)
     user = models.CharField(max_length=15, db_index=True)
@@ -38,22 +33,21 @@ class Tweet(models.Model):
         ordering = ("-created",)
 
     def __str__(self):
-        return "@%s - %s" % (self.user, self.text)
+        return "@{} - {}".format(self.user, self.text)
 
     def get_absolute_url(self):
-        return "https://twitter.com/%s/status/%s" % (self.user, self.tweet_id)
+        return "https://twitter.com/{}/status/{}".format(self.user, self.tweet_id)
 
     def user_url(self):
-        return "https://twitter.com/%s" % (self.user,)
+        return "https://twitter.com/{}".format(self.user)
 
     def retweeted_user_url(self):
         if self.retweeted_username:
-            return "https://twitter.com/%s" % (self.retweeted_username,)
+            return "https://twitter.com/{}".format(self.retweeted_username)
         else:
             return None
 
 
-@python_2_unicode_compatible
 class Photo(models.Model):
     tweet = models.ForeignKey(Tweet, on_delete=models.CASCADE, related_name="photos")
     photo_id = models.BigIntegerField("Photo ID")
@@ -76,10 +70,9 @@ class Photo(models.Model):
         return self.url
 
     def large_url(self):
-        return "%s:large" % (self.media_url,)
+        return "{}:large".format(self.media_url)
 
 
-@python_2_unicode_compatible
 class Like(models.Model):
     user = models.CharField(max_length=15)
     tweet = models.ForeignKey(Tweet, on_delete=models.CASCADE)
@@ -89,4 +82,4 @@ class Like(models.Model):
         unique_together = (("user", "tweet"),)
 
     def __str__(self):
-        return "%s" % (self.tweet,)
+        return str(self.tweet)

--- a/latest_tweets/models.py
+++ b/latest_tweets/models.py
@@ -9,67 +9,65 @@ class Hashtag(models.Model):
     text = models.CharField(max_length=140, unique=True)
 
     class Meta:
-        ordering = ('text',)
+        ordering = ("text",)
 
     def __str__(self):
         return self.text
 
     def get_absolute_url(self):
-        return 'https://twitter.com/hashtag/%s' % (self.text,)
+        return "https://twitter.com/hashtag/%s" % (self.text,)
 
 
 @python_2_unicode_compatible
 class Tweet(models.Model):
-    tweet_id = models.BigIntegerField('Tweet ID', unique=True)
+    tweet_id = models.BigIntegerField("Tweet ID", unique=True)
     user = models.CharField(max_length=15, db_index=True)
     name = models.CharField(max_length=50)
     text = models.CharField(max_length=250)
-    html = models.TextField('HTML')
+    html = models.TextField("HTML")
     hashtags = models.ManyToManyField(Hashtag, blank=True)
     favorite_count = models.PositiveIntegerField(default=0)
     retweet_count = models.PositiveIntegerField(default=0)
     retweeted_username = models.CharField(max_length=20, blank=True)
     retweeted_name = models.CharField(max_length=50, blank=True)
-    retweeted_tweet_id = models.BigIntegerField('Retweeted tweet ID', null=True, blank=True)
+    retweeted_tweet_id = models.BigIntegerField("Retweeted tweet ID", null=True, blank=True)
     is_reply = models.BooleanField(default=False, db_index=True)
     created = models.DateTimeField(db_index=True)
 
     class Meta:
-        ordering = ('-created',)
+        ordering = ("-created",)
 
     def __str__(self):
-        return '@%s - %s' % (self.user, self.text)
+        return "@%s - %s" % (self.user, self.text)
 
     def get_absolute_url(self):
-        return 'https://twitter.com/%s/status/%s' % (self.user, self.tweet_id)
+        return "https://twitter.com/%s/status/%s" % (self.user, self.tweet_id)
 
     def user_url(self):
-        return 'https://twitter.com/%s' % (self.user,)
+        return "https://twitter.com/%s" % (self.user,)
 
     def retweeted_user_url(self):
         if self.retweeted_username:
-            return 'https://twitter.com/%s' % (self.retweeted_username,)
+            return "https://twitter.com/%s" % (self.retweeted_username,)
         else:
             return None
 
 
 @python_2_unicode_compatible
 class Photo(models.Model):
-    tweet = models.ForeignKey(Tweet, on_delete=models.CASCADE, related_name='photos')
-    photo_id = models.BigIntegerField('Photo ID')
+    tweet = models.ForeignKey(Tweet, on_delete=models.CASCADE, related_name="photos")
+    photo_id = models.BigIntegerField("Photo ID")
     text = models.CharField(max_length=250)
     text_index = models.PositiveIntegerField(db_index=True)
-    url = models.URLField('URL')
-    media_url = models.URLField('Media URL')
+    url = models.URLField("URL")
+    media_url = models.URLField("Media URL")
     large_width = models.PositiveIntegerField()
     large_height = models.PositiveIntegerField()
-    image_file = models.ImageField(upload_to='latest_tweets/photo', blank=True)
+    image_file = models.ImageField(upload_to="latest_tweets/photo", blank=True)
 
     class Meta:
-        ordering = ('tweet', 'text_index')
-        unique_together = (
-            ('tweet', 'photo_id'),
-        )
+        ordering = ("tweet", "text_index")
+        unique_together = (("tweet", "photo_id"),)
 
     def __str__(self):
         return self.text
@@ -78,7 +76,7 @@ class Photo(models.Model):
         return self.url
 
     def large_url(self):
-        return '%s:large' % (self.media_url,)
+        return "%s:large" % (self.media_url,)
 
 
 @python_2_unicode_compatible
@@ -87,10 +85,8 @@ class Like(models.Model):
     tweet = models.ForeignKey(Tweet, on_delete=models.CASCADE)
 
     class Meta:
-        ordering = ('-tweet',)
-        unique_together = (
-            ('user', 'tweet'),
-        )
+        ordering = ("-tweet",)
+        unique_together = (("user", "tweet"),)
 
     def __str__(self):
-        return '%s' % (self.tweet,)
+        return "%s" % (self.tweet,)

--- a/latest_tweets/templatetags/latest_tweets_tags.py
+++ b/latest_tweets/templatetags/latest_tweets_tags.py
@@ -1,4 +1,3 @@
-import django
 from django import template
 
 from latest_tweets.models import Hashtag, Tweet
@@ -6,13 +5,7 @@ from latest_tweets.models import Hashtag, Tweet
 register = template.Library()
 
 
-if django.VERSION >= (1, 9):
-    assignment_tag = register.simple_tag
-else:
-    assignment_tag = register.assignment_tag
-
-
-@assignment_tag
+@register.simple_tag
 def get_latest_tweets(*args, **kwargs):
     limit = kwargs.pop("limit", None)
     include_replies = kwargs.pop("include_replies", False)

--- a/latest_tweets/templatetags/latest_tweets_tags.py
+++ b/latest_tweets/templatetags/latest_tweets_tags.py
@@ -1,5 +1,6 @@
 import django
 from django import template
+
 from latest_tweets.models import Hashtag, Tweet
 
 register = template.Library()
@@ -13,10 +14,10 @@ else:
 
 @assignment_tag
 def get_latest_tweets(*args, **kwargs):
-    limit = kwargs.pop('limit', None)
-    include_replies = kwargs.pop('include_replies', False)
-    liked_by = kwargs.pop('liked_by', None)
-    hashtag = kwargs.pop('hashtag', None)
+    limit = kwargs.pop("limit", None)
+    include_replies = kwargs.pop("include_replies", False)
+    liked_by = kwargs.pop("liked_by", None)
+    hashtag = kwargs.pop("hashtag", None)
     tweets = Tweet.objects.all()
 
     #  By default we exclude replies

--- a/latest_tweets/utils.py
+++ b/latest_tweets/utils.py
@@ -1,11 +1,9 @@
-from __future__ import unicode_literals
-
 import hashlib
 from datetime import datetime
+from html import unescape
 from tempfile import TemporaryFile
 
 from django.core.files import File
-from django.utils.six.moves import html_parser
 from django.utils.timezone import utc
 
 import requests
@@ -106,10 +104,6 @@ def tweet_photos(tweet, media, download):
 
 
 def update_tweets(tweet_list, tweet_entities=tweet_html_entities, download=False):
-    # Need to escape HTML entities
-    htmlparser = html_parser.HTMLParser()
-    unescape = htmlparser.unescape
-
     obj_list = []
 
     for tweet in tweet_list:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,0 +1,3 @@
+-r testing.txt
+
+Django>=2.2,<3.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,3 +1,6 @@
 -r testing.txt
 
+bump2version==1.0.1
 Django>=2.2,<3.0
+tox==3.20.1
+twine==3.2.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,0 +1,3 @@
+Pillow==7.2.0
+requests==2.24.0
+twitter==1.18.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,3 +1,8 @@
+black==20.8b1 ; python_version >= '3.6'
+coverage==5.3
+flake8==3.8.4
+isort==4.3.21
 Pillow==7.2.0
+pipdeptree==1.0.0
 requests==2.24.0
 twitter==1.18.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal = 1
+python-tag = py3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "twitter>=1.9.1",
         "requests>=2.0",
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     classifiers=[
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,27 @@
 #!/usr/bin/env python
-from codecs import open
+import os
 
 from setuptools import find_packages, setup
 
-with open("README.rst", "r", "utf-8") as f:
-    readme = f.read()
+
+def read(filename):
+    with open(os.path.join(os.path.dirname(__file__), filename)) as f:
+        return f.read()
 
 
 setup(
     name="django-latest-tweets",
     version="0.4.6",
     description="Latest Tweets for Django",
-    long_description=readme,
+    long_description=read("README.rst"),
+    long_description_content_type="text/x-rst",
     url="https://github.com/developersociety/django-latest-tweets",
     maintainer="The Developer Society",
     maintainer_email="studio@dev.ngo",
     platforms=["any"],
+    python_requires=">=3.5",
     install_requires=[
+        "Django>=1.11",
         "twitter>=1.9.1",
         "requests>=2.0",
     ],
@@ -24,21 +29,18 @@ setup(
     include_package_data=True,
     classifiers=[
         "Environment :: Web Environment",
-        "Framework :: Django",
-        "Framework :: Django :: 1.8",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.2",
+        "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Framework :: Django",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.2",
     ],
     license="BSD",
 )

--- a/setup.py
+++ b/setup.py
@@ -3,43 +3,42 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-
-with open('README.rst', 'r', 'utf-8') as f:
+with open("README.rst", "r", "utf-8") as f:
     readme = f.read()
 
 
 setup(
-    name='django-latest-tweets',
-    version='0.4.6',
-    description='Latest Tweets for Django',
+    name="django-latest-tweets",
+    version="0.4.6",
+    description="Latest Tweets for Django",
     long_description=readme,
-    url='https://github.com/developersociety/django-latest-tweets',
-    maintainer='The Developer Society',
-    maintainer_email='studio@dev.ngo',
-    platforms=['any'],
+    url="https://github.com/developersociety/django-latest-tweets",
+    maintainer="The Developer Society",
+    maintainer_email="studio@dev.ngo",
+    platforms=["any"],
     install_requires=[
-        'twitter>=1.9.1',
-        'requests>=2.0',
+        "twitter>=1.9.1",
+        "requests>=2.0",
     ],
     packages=find_packages(),
     include_package_data=True,
     classifiers=[
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.2',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Framework :: Django :: 1.8",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.2",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
-    license='BSD',
+    license="BSD",
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,10 @@
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+
+SECRET_KEY = "latest_tweets"
+
+INSTALLED_APPS = ["latest_tweets", "tests"]
+
+TWITTER_OAUTH_TOKEN = "DEMO"
+TWITTER_OAUTH_SECRET = "DEMO"
+TWITTER_CONSUMER_KEY = "DEMO"
+TWITTER_CONSUMER_SECRET = "DEMO"

--- a/tests/test_command_latest_tweets_update.py
+++ b/tests/test_command_latest_tweets_update.py
@@ -1,0 +1,14 @@
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class LatestTweetsUpdateTest(TestCase):
+    @mock.patch("twitter.api.TwitterCall.__call__")
+    def test_command(self, mock_twitter_call):
+        mock_twitter_call.return_value = []
+
+        result = call_command("latest_tweets_update", "demo")
+
+        self.assertIsNone(result)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+from django.utils import timezone
+
+from latest_tweets.models import Hashtag, Tweet
+
+
+class HashtagTest(TestCase):
+    def test_create(self):
+        obj = Hashtag.objects.create(text="HashTag")
+        self.assertIsNotNone(obj.id)
+
+    def test_str(self):
+        obj = Hashtag(text="HashTag")
+        self.assertEqual(str(obj), "HashTag")
+
+    def test_get_absolute_url(self):
+        obj = Hashtag(text="HashTag")
+        self.assertEqual(obj.get_absolute_url(), "https://twitter.com/hashtag/HashTag")
+
+
+class TweetTest(TestCase):
+    def test_create(self):
+        obj = Tweet.objects.create(tweet_id=123, created=timezone.now())
+        self.assertIsNotNone(obj.id)
+
+    def test_str(self):
+        obj = Tweet(tweet_id=123, user="Alice", text="Hello World", created=timezone.now())
+        self.assertEqual(str(obj), "@Alice - Hello World")
+
+    def test_get_absolute_url(self):
+        obj = Tweet(tweet_id=123, user="Alice", created=timezone.now())
+        self.assertEqual(obj.get_absolute_url(), "https://twitter.com/Alice/status/123")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+
+from latest_tweets.utils import tweet_html_entities
+
+
+class TweetHTMLEntitiesTest(TestCase):
+    def test_text_only(self):
+        tweet_html = tweet_html_entities(tweet="Hello world")
+
+        self.assertEqual(tweet_html, "Hello world")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+envlist =
+    check
+    lint
+    {py35,py36,py37}-django1.11
+    {py35,py36,py37,py38}-django2.2
+    coverage
+skipsdist = true
+
+[testenv]
+deps =
+    -rrequirements/testing.txt
+    django1.11: Django>=1.11,<2.0
+    django2.2: Django>=2.2,<3.0
+whitelist_externals = make
+commands = make test
+usedevelop = true
+setenv =
+    PYTHONWARNINGS = all
+
+[testenv:check]
+basepython = python3.8
+commands = make check
+skip_install = true
+
+[testenv:lint]
+basepython = python3.8
+commands = make lint
+skip_install = true
+
+[testenv:coverage]
+basepython = python3.8
+commands = make coverage-report
+skip_install = true


### PR DESCRIPTION
This package isn't really one of our most commonly used Django apps anymore, however as there's one Django 2.2 site using it - I'm moving this forward with updates to get it ready for Django 3.2 at some point.

A huge bunch of changes to make it a Python 3 only codebase, raising the minimum Django version to 1.11, adding Black.

I've added a few bare minimum tests - this is just a starting point. If there's spare time then a few more can be added at a later date.

To test:

- Try this on churchinwales
- Copy TWITTER env vars from the live instance
- `pip install -e git+ssh://git@github.com/developersociety/django-latest-tweets.git@modern-python-django#egg=django-latest-tweets`
- `./manage.py latest_tweets_update devsociety_`