### PR TITLE
🎃 Various updates

### DIFF
--- a/.github/matrix.py
+++ b/.github/matrix.py
@@ -1,0 +1,32 @@
+import fileinput
+import json
+import re
+import sys
+
+PY_VERSIONS_RE = re.compile(r"^py(\d)(\d+)")
+
+
+def main():
+    actions_matrix = []
+
+    for tox_env in fileinput.input():
+        tox_env = tox_env.rstrip()
+
+        if python_match := PY_VERSIONS_RE.match(tox_env):
+            version_tuple = python_match.groups()
+        else:
+            version_tuple = sys.version_info[0:2]
+
+        python_version = "{}.{}".format(*version_tuple)
+        actions_matrix.append(
+            {
+                "python": python_version,
+                "tox_env": tox_env,
+            }
+        )
+
+    print(json.dumps(actions_matrix))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,84 +1,51 @@
 name: CI
 on: pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
-  check:
-    name: Check
+  matrix:
+    name: Build test matrix
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - name: Python pip cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/testing.txt') }}
-      - name: Run check
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
+      - name: Run tox
+        id: matrix
         run: |
-          pip install tox
-          tox -e check
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-      - name: Python pip cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/testing.txt') }}
-      - name: Run lint
-        run: |
-          pip install tox
-          tox -e lint
+          pip install $(grep "^tox==" requirements/local.txt)
+          echo "tox_matrix=$(tox -l | fgrep -v coverage | python .github/matrix.py)" >> "$GITHUB_OUTPUT"
+    outputs:
+      tox_matrix: ${{ steps.matrix.outputs.tox_matrix }}
 
   test:
-    name: Test -- Python ${{ matrix.python }} - Django ${{ matrix.django }}
+    name: Test -- ${{ matrix.tox_env }}
     runs-on: ubuntu-20.04
+    needs: matrix
     strategy:
       matrix:
-        python:
-          - '3.5'
-          - '3.6'
-          - '3.7'
-          - '3.8'
-          - '3.9'
-        django:
-          - '1.11'
-          - '2.2'
-          - '3.2'
-        exclude:
-          - python: '3.5'
-            django: '3.2'
-          - python: '3.8'
-            django: '1.11'
-          - python: '3.9'
-            django: '1.11'
+        include: ${{ fromJson(needs.matrix.outputs.tox_matrix) }}
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - name: Python pip cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python${{ matrix.python }}-django${{ matrix.django }}-pip-${{ hashFiles('requirements/testing.txt') }}
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
       - name: Run tests
-        env:
-          PYTHON_VERSION: ${{ matrix.python }}
         run: |
-          pip install tox
-          tox -e py${PYTHON_VERSION//./}-django${{ matrix.django }}
+          pip install $(grep "^tox==" requirements/local.txt)
+          tox -e ${{ matrix.tox_env }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
       - name: Run tox

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2021, Developer Society Limited
+Copyright (c) 2012-2022, Developer Society Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/latest_tweets/__init__.py
+++ b/latest_tweets/__init__.py
@@ -1,3 +1,7 @@
+import django
+
 __version__ = "0.4.6"
 
-default_app_config = "latest_tweets.apps.LatestTweetsConfig"
+
+if django.VERSION < (3, 2):
+    default_app_config = "latest_tweets.apps.LatestTweetsConfig"

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,5 +2,5 @@
 
 bump2version==1.0.1
 Django>=3.2,<4.0
-tox==3.24.4
-twine==3.4.2
+tox==3.25.0
+twine==4.0.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,8 +1,8 @@
-black==22.3.0 ; python_version >= '3.6'
+black==22.8.0 ; python_version >= '3.6'
 coverage==5.5
 flake8==3.9.2
-isort==5.9.3 ; python_version >= '3.6'
+isort==5.10.1 ; python_version >= '3.6'
 Pillow==7.2.0
-pipdeptree==2.2.0
+pipdeptree==2.2.1
 requests==2.25.1
 twitter==1.18.0

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Framework :: Django",
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.2",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     lint
     {py35,py36,py37}-django1.11
     {py35,py36,py37,py38,py39}-django2.2
-    {py36,py37,py38,py39}-django3.2
+    {py36,py37,py38,py39,py310}-django3.2
     coverage
 skipsdist = true
 
@@ -19,16 +19,16 @@ commands = make test
 usedevelop = true
 
 [testenv:check]
-basepython = python3.9
+basepython = python3.10
 commands = make check
 skip_install = true
 
 [testenv:lint]
-basepython = python3.9
+basepython = python3.10
 commands = make lint
 skip_install = true
 
 [testenv:coverage]
-basepython = python3.9
+basepython = python3.10
 commands = make coverage-report
 skip_install = true


### PR DESCRIPTION
Mostly bumping the package up for Django 3.2 fixes, Python 3.10 support. Also improved the GitHub Actions CI setup (especially with upcoming deprecations).

Feels like déjà vu from #14 - moving the package along a bit so it doesn't become a blocker to upgrading a project.

To test:

- Try this on churchinwales
- Copy TWITTER env vars from the live instance
- `pip install -e git+ssh://git@github.com/developersociety/django-latest-tweets.git@various-updates#egg=django-latest-tweets`
- `./manage.py latest_tweets_update devsociety_`