### PR TITLE
Bump version: 0.4.6 → 0.4.7

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.6
+current_version = 0.4.7
 commit = True
 tag = True
 tag_name = {new_version}

--- a/latest_tweets/__init__.py
+++ b/latest_tweets/__init__.py
@@ -1,6 +1,6 @@
 import django
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 
 if django.VERSION < (3, 2):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(filename):
 
 setup(
     name="django-latest-tweets",
-    version="0.4.6",
+    version="0.4.7",
     description="Latest Tweets for Django",
     long_description=read("README.rst"),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
So we can get a Django 3.2 compatible version out - though this is low priority.